### PR TITLE
ci: push only intended image tag to prevent prod tag overwrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,14 +145,18 @@ jobs:
         echo "Building and pushing Docker image..."
         echo "$DOCKER_TOKEN" | docker login docker.io -u "$DOCKER_USERNAME" --password-stdin
 
-        # Configure Jib to use the environment-specific tag
-        export IMAGE_TAG
-        ./gradlew jib -Djib.to.tags=$IMAGE_TAG
+        IMAGE_REF="$DOCKER_REGISTRY/$DOCKER_USERNAME/spring-sse-example"
 
-        echo "✅ Successfully pushed image: $DOCKER_REGISTRY/$DOCKER_USERNAME/spring-sse-example:$IMAGE_TAG"
+        # Override the FULL destination image, not jib.to.tags.
+        # jib.to.tags only adds tags and still pushes the tag baked into
+        # jib.to.image (project.version). On a feature branch that would also
+        # republish the plain release tag and clobber the production image.
+        ./gradlew jib -Djib.to.image="$IMAGE_REF:$IMAGE_TAG"
 
-        # Also tag as 'latest' for main branch
+        echo "✅ Successfully pushed image: $IMAGE_REF:$IMAGE_TAG"
+
+        # Also tag as 'latest' for main branch only
         if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-          ./gradlew jib -Djib.to.tags=latest
+          ./gradlew jib -Djib.to.image="$IMAGE_REF:latest"
           echo "✅ Also tagged as: latest"
         fi


### PR DESCRIPTION
## What
Fixes the CI Docker job so a feature-branch build can no longer overwrite the released production image tag.

## Why (#28)
`jib.to.tags` only *adds* tags — Jib still pushes the tag baked into `jib.to.image`, which `build.gradle` sets to `project.version` (`1.0.1`). So on a `feature/docker*` branch the job pushed **both** `1.0.1-dev-<sha>` and `1.0.1`, clobbering the semver tag reserved for production.

## Change
- Override the full destination with `-Djib.to.image=<registry>/<user>/spring-sse-example:<tag>` so exactly one tag is pushed per invocation.
- `latest` is pushed only on `main`, via its own explicit override.

Verified: YAML parses; no `jib.to.tags` invocations remain.

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)