### PR TITLE
bugfix: app-code security hardening (XSS, JSON injection, CORS)

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -13,10 +13,9 @@ data:
   management.endpoints.web.exposure.include: "health,info,metrics"
   management.endpoint.health.show-details: "when_authorized"
   
-  # CORS configuration - restrict in production
-  spring.web.cors.allowed-origins: "*"
-  spring.web.cors.allowed-methods: "GET,POST,OPTIONS"
-  spring.web.cors.allowed-headers: "*"
+  # CORS configuration - consumed by CorsConfig (app.cors.allowed-origins).
+  # Restrict in production overlays. Methods are fixed in CorsConfig.
+  app.cors.allowed-origins: "*"
   
   # SSE configuration
   spring.mvc.async.request-timeout: "0"

--- a/k8s/overlays/dev/configmap-patch.yaml
+++ b/k8s/overlays/dev/configmap-patch.yaml
@@ -11,4 +11,4 @@ data:
   logging.level.org.springframework.web: "INFO"
 
   # Dev-specific CORS (can be more restrictive than minikube)
-  spring.web.cors.allowed-origins: "*"  # TODO: Update with actual dev domains
+  app.cors.allowed-origins: "*"  # TODO: Update with actual dev domains

--- a/k8s/overlays/prod/configmap-patch.yaml
+++ b/k8s/overlays/prod/configmap-patch.yaml
@@ -12,4 +12,4 @@ data:
   logging.level.root: "ERROR"
 
   # Production CORS - MUST BE UPDATED with actual domains
-  spring.web.cors.allowed-origins: "https://your-production-domain.com"  # TODO: Update with actual production domain
+  app.cors.allowed-origins: "https://your-production-domain.com"  # TODO: Update with actual production domain

--- a/src/main/java/com/example/sseexample/config/CorsConfig.java
+++ b/src/main/java/com/example/sseexample/config/CorsConfig.java
@@ -1,0 +1,28 @@
+package com.example.sseexample.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Profile-agnostic CORS policy driven by the {@code app.cors.allowed-origins}
+ * property (comma-separated). Dev defaults to "*"; production overlays set
+ * explicit origins. Replaces the hardcoded {@code @CrossOrigin(origins = "*")}.
+ */
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    private final String[] allowedOrigins;
+
+    public CorsConfig(@Value("${app.cors.allowed-origins:*}") String allowedOrigins) {
+        this.allowedOrigins = allowedOrigins.split("\\s*,\\s*");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins(allowedOrigins)
+            .allowedMethods("GET", "POST", "OPTIONS");
+    }
+}

--- a/src/main/java/com/example/sseexample/controller/EventController.java
+++ b/src/main/java/com/example/sseexample/controller/EventController.java
@@ -8,7 +8,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api")
-@CrossOrigin(origins = "*")
 public class EventController {
 
     private final EventService eventService;

--- a/src/main/java/com/example/sseexample/service/EventService.java
+++ b/src/main/java/com/example/sseexample/service/EventService.java
@@ -1,11 +1,15 @@
 package com.example.sseexample.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -16,6 +20,7 @@ public class EventService {
 
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public EventService() {
         this(true);
@@ -48,9 +53,8 @@ public class EventService {
     }
 
     public void broadcastEvent(String eventName, String data) {
-        String timestamp = getCurrentTimestamp();
-        String eventData = String.format("{\"message\":\"%s\", \"timestamp\":\"%s\"}", data, timestamp);
-        
+        String eventData = buildPayload(data);
+
         emitters.removeIf(emitter -> {
             try {
                 emitter.send(SseEmitter.event()
@@ -80,6 +84,18 @@ public class EventService {
             String randomMessage = sampleMessages[(int) (Math.random() * sampleMessages.length)];
             broadcastEvent("notification", randomMessage);
         }, 10, 15, TimeUnit.SECONDS);
+    }
+
+    String buildPayload(String message) {
+        Map<String, String> payload = new LinkedHashMap<>();
+        payload.put("message", message);
+        payload.put("timestamp", getCurrentTimestamp());
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            // String values cannot fail serialization; fall back defensively.
+            return "{\"message\":null,\"timestamp\":null}";
+        }
     }
 
     private String getCurrentTimestamp() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,9 @@
 server.port=8080
 spring.application.name=sse-example
 
-# Enable CORS for development
-spring.web.cors.allowed-origins=*
-spring.web.cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS
-spring.web.cors.allowed-headers=*
+# CORS allowed origins (comma-separated), consumed by CorsConfig.
+# Dev default is permissive; production must override with explicit origins.
+app.cors.allowed-origins=*
 
 # Dev tools configuration
 spring.devtools.restart.enabled=true

--- a/src/main/resources/static/test.html
+++ b/src/main/resources/static/test.html
@@ -108,7 +108,12 @@
                 // If not JSON, use as is
             }
             
-            eventDiv.innerHTML = `<strong>[${type.toUpperCase()}]</strong> ${timestamp}: ${message}`;
+            // Build via DOM/textContent, never innerHTML: message is server-broadcast,
+            // attacker-controllable input and must not be parsed as HTML (XSS).
+            const label = document.createElement('strong');
+            label.textContent = `[${type.toUpperCase()}]`;
+            eventDiv.appendChild(label);
+            eventDiv.appendChild(document.createTextNode(` ${timestamp}: ${message}`));
             eventLog.appendChild(eventDiv);
             eventLog.scrollTop = eventLog.scrollHeight;
         }

--- a/src/test/java/com/example/sseexample/config/CorsConfigTest.java
+++ b/src/test/java/com/example/sseexample/config/CorsConfigTest.java
@@ -1,0 +1,38 @@
+package com.example.sseexample.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "app.cors.allowed-origins=https://allowed.example.com")
+class CorsConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void preflight_fromConfiguredOrigin_echoesThatOrigin() throws Exception {
+        mockMvc.perform(options("/api/trigger-event")
+                .header("Origin", "https://allowed.example.com")
+                .header("Access-Control-Request-Method", "POST"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Access-Control-Allow-Origin", "https://allowed.example.com"));
+    }
+
+    @Test
+    void preflight_fromUnlistedOrigin_isRejected() throws Exception {
+        mockMvc.perform(options("/api/trigger-event")
+                .header("Origin", "https://evil.example.com")
+                .header("Access-Control-Request-Method", "POST"))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/example/sseexample/service/EventServiceTest.java
+++ b/src/test/java/com/example/sseexample/service/EventServiceTest.java
@@ -179,6 +179,33 @@ class EventServiceTest {
     }
 
     @Test
+    void buildPayload_WithQuoteInMessage_ProducesValidJson() throws Exception {
+        // Given a message containing characters that would break naive string formatting
+        String message = "he said \"hi\" and \\ backslash";
+
+        // When
+        String json = eventService.buildPayload(message);
+
+        // Then it must be valid JSON whose message field equals the original input
+        com.fasterxml.jackson.databind.JsonNode node =
+            new com.fasterxml.jackson.databind.ObjectMapper().readTree(json);
+        assertEquals(message, node.get("message").asText());
+        assertTrue(node.has("timestamp"));
+    }
+
+    @Test
+    void buildPayload_WithNullMessage_ProducesValidJson() throws Exception {
+        // When
+        String json = eventService.buildPayload(null);
+
+        // Then it must still be valid JSON (no injection, no crash)
+        com.fasterxml.jackson.databind.JsonNode node =
+            new com.fasterxml.jackson.databind.ObjectMapper().readTree(json);
+        assertTrue(node.has("message"));
+        assertTrue(node.has("timestamp"));
+    }
+
+    @Test
     void concurrentConnections_ShouldHandleMultipleEmitters() throws Exception {
         // Given
         EventService service = new EventService(false);


### PR DESCRIPTION
Fixes the three high-severity application-code findings from the security review.

## Changes
- **XSS (#9):** test client renders event data via `textContent`/DOM nodes instead of `innerHTML`, closing the stored-XSS path from `/api/trigger-event` to every connected browser.
- **JSON injection (#10):** `EventService.buildPayload` serializes via Jackson instead of `String.format`, so quotes/backslashes in messages can no longer break out of the JSON payload. TDD coverage added.
- **CORS (#12):** removed hardcoded `@CrossOrigin(origins = "*")`; added `CorsConfig` (`WebMvcConfigurer`) driven by `app.cors.allowed-origins` (comma-separated). Dropped the no-op `spring.web.cors.*` keys from `application.properties` and renamed the k8s configmap keys to `app.cors.allowed-origins` so prod is actually restricted to its domain. TDD preflight coverage added.

## Notes
- #11 (auth on `/trigger-event`) was closed **wontfix** — intentional for this demo app.
- Tests: `./gradlew test` green; all three kustomize overlays build.

Closes #9
Closes #10
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)